### PR TITLE
Be explicit about source version of Lena image in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,7 +57,7 @@ rgb_line = colorview(RGB, linspace(0,1,20), zeroarray, linspace(1,0,20))
 camera_man = testimage("camera")
 lighthouse = testimage("lighthouse")
 toucan = testimage("toucan")
-lena = testimage("lena")
+lena = testimage("lena_color_256")
 
 # ====================================================================
 
@@ -73,4 +73,3 @@ for t in tests
         include(t)
     end
 end
-


### PR DESCRIPTION
I had a grayscale version on my machine, and `testimage("lena")` grabs anything matching it can find. This caused a disagreement with the reference image during tests.