### PR TITLE
Print several images from Array{T,3}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 ColorTypes = ">= 0.3.2"

--- a/src/ImageInTerminal.jl
+++ b/src/ImageInTerminal.jl
@@ -39,6 +39,13 @@ Call `ImageInTerminal.use_256()` to restore default behaviour.
 use_24bit() = (colormode[1] = TermColor24bit())
 
 # colorant arrays
+function Base.show(
+        io::IO, ::MIME"text/plain",
+        img::AbstractVecOrMat{<:Colorant})
+    println(io, summary(img), ":")
+    ImageInTerminal.imshow(io, img, colormode[1])
+end
+
 function Base.print_matrix(
         io::IO,
         img::AbstractVecOrMat{<:Colorant})

--- a/src/ImageInTerminal.jl
+++ b/src/ImageInTerminal.jl
@@ -39,10 +39,9 @@ Call `ImageInTerminal.use_256()` to restore default behaviour.
 use_24bit() = (colormode[1] = TermColor24bit())
 
 # colorant arrays
-function Base.show(
-        io::IO, ::MIME"text/plain",
+function Base.print_matrix(
+        io::IO,
         img::AbstractVecOrMat{<:Colorant})
-    println(io, summary(img), ":")
     ImageInTerminal.imshow(io, img, colormode[1])
 end
 


### PR DESCRIPTION
Today I wondered why `cat(img, img2, dims=3)` couldn't print both of them. This change makes that happen, at least in the terminal. It's possible that dropping the mime type is too crude, and will break something else? Test pass once I `add SparseArrays`. 

Before:
```
julia> Gray.(rand(2,16,2))
2×16×2 Array{Gray{Float64},3} with eltype Gray{Float64}:
[:, :, 1] =
 Gray{Float64}(0.110167)  Gray{Float64}(0.432585)  …  Gray{Float64}(0.317969)
 Gray{Float64}(0.291839)  Gray{Float64}(0.763979)     Gray{Float64}(0.798896)

[:, :, 2] =
 Gray{Float64}(0.405303)  Gray{Float64}(0.104343)  …  Gray{Float64}(0.167008)
 Gray{Float64}(0.741177)  Gray{Float64}(0.99729)      Gray{Float64}(0.624645)
```
After:
```
julia> Gray.(rand(2,16,2))
2×16×2 Array{Gray{Float64},3} with eltype Gray{Float64}:
[:, :, 1] =
████████████████████████████████
████████████████████████████████

[:, :, 2] =
████████████████████████████████
████████████████████████████████

```