### PR TITLE
remove ColorTypes and FixedPointNumbers from dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,23 +1,20 @@
 name = "ImageInTerminal"
 uuid = "d8c32880-2388-543b-8c61-d9f865259254"
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 
 [compat]
-ColorTypes = "0.7, 0.8"
 Crayons = "0.5, 1, 2, 3, 4"
-ImageCore = "0.7, 0.8"
+ImageCore = "0.8.1"
 ImageTransformations = "0.5, 0.6, 0.7, 0.8"
 julia = "1"
 
 [extras]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
@@ -26,4 +23,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = [ "CoordinateTransformations", "FixedPointNumbers", "ImageMagick", "Rotations", "SparseArrays", "OffsetArrays", "Test", "TestImages"]
+test = ["CoordinateTransformations", "ImageMagick", "Rotations", "SparseArrays", "OffsetArrays", "Test", "TestImages"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageInTerminal"
 uuid = "d8c32880-2388-543b-8c61-d9f865259254"
-version = "0.5.0"
+version = "0.4.2"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/src/ImageInTerminal.jl
+++ b/src/ImageInTerminal.jl
@@ -1,7 +1,6 @@
 module ImageInTerminal
 
 using Crayons
-using ColorTypes
 using ImageCore
 using ImageTransformations
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
-using ImageInTerminal, ImageCore, ColorTypes, FixedPointNumbers
+using ImageInTerminal, ImageCore
 using TestImages, ImageTransformations, CoordinateTransformations
-using ImageMagick
 using Rotations, OffsetArrays
 using SparseArrays
 using Test


### PR DESCRIPTION
closes #24 

ImageCore v0.8.1 reexports `FixedPointNumbers` and `Colors`, so in this package, we don't need to directly manage them as dependencies (unless we need some latest features but we don't)

@Evizero This was mainly developed by you, so I think it's better to let you do the choice here