### PR TITLE
automatically use 24bit if the terminal supports it

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageInTerminal"
 uuid = "d8c32880-2388-543b-8c61-d9f865259254"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Images) are displayed in the interactive REPL.
 The displayed images will be downscaled to fit into the size of
 your active terminal session.
 
+To activate this package simply import it into your Julia session.
+
 ### Without this package
 
 ```julia
@@ -55,6 +57,30 @@ julia> colorview(RGB, rand(3, 10, 10))
 ```
 
 ![ImageInTerminal](https://cloud.githubusercontent.com/assets/10854026/22923639/92e3b164-f2a2-11e6-85ea-b92bdc4a63e0.png)
+
+### 256 colors and 24-bit colors
+
+By default this packages will detect if your running terminal supports
+24 bit colors, i.e., true color. If it does, then the image will be
+displayed in 24-bit colors, otherwise it will use 256 colors as a fallback
+option. To manually switch between 24-bit colors and 256 colors, you can
+use the internal helpers:
+
+```julia
+using ImageInTerminal
+ImageInTerminal.use_24bit()
+ImageInTerminal.use_256()
+```
+
+Note that 24 bits format only works as expected if your terminal supports it,
+otherwise you are likely to get some random outputs. To check if your terminal
+supports 24 bits color, please check if the environment variable `COLORTERM` is
+`24bit`(or `truecolor`).
+
+Here's how images are displayed in 24-bit colors:
+
+![24bit color](https://user-images.githubusercontent.com/8684355/76688030-26169b80-6664-11ea-96da-72e348835634.png)
+
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,6 @@ Images) are displayed in the interactive REPL.
 The displayed images will be downscaled to fit into the size of
 your active terminal session.
 
-To activate this package simply import it into your Julia session.
-By default this packages uses 256 colors. If your terminal supports
-24 bit colors you can make use of them by typing the following:
-
-```julia
-using ImageInTerminal
-ImageInTerminal.use_24bit()
-````
-
 ### Without this package
 
 ```julia

--- a/src/ImageInTerminal.jl
+++ b/src/ImageInTerminal.jl
@@ -54,4 +54,9 @@ function Base.show(io::IO, ::MIME"text/plain", color::Colorant)
     print(io, Crayon(reset = true))
 end
 
+function __init__()
+    # use 24bit if the terminal supports it
+    lowercase(get(ENV, "COLORTERM", "")) in ("24bit", "truecolor") && use_24bit()
+end
+
 end # module


### PR DESCRIPTION
Not sure if this covers all cases, but it works on iTerm2

Ref: https://gist.github.com/XVilka/8346728#true-color-detection

![image](https://user-images.githubusercontent.com/8684355/76688541-a17a4c00-6668-11ea-9fb9-41669fbec07e.png)


