### PR TITLE
Add play and explore for 3D and framestack image playback/interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,31 @@ If you want to temporarily disable this package, you can call `ImageInTerminal.d
 restore the encoding functionality with `ImageInTerminal.enable_encoding()`. `ImageInTerminal.use_24bit()`
 and `ImageInTerminal.use_256()` will also enable encodings, too.
 
+### Exploring framestacks and 3D image arrays
+
+The `play` and `explore` functions allow playback and exploration of stacks of images, or to move along a given
+dimension in a 3D image array.
+
+```julia
+using ImageInTerminal, TestImages
+img3D = testimage("mri-stack")
+explore(img, 3) # explore along dimension 3
+```
+![explore mri](https://user-images.githubusercontent.com/1694067/109374814-1351a280-7886-11eb-956e-c08403ae9afb.png)
+
+```julia
+using ImageInTerminal, ImageCore
+framestack = map(_->rand(Gray{N0f8}, 100, 100), 1:200)
+play(framestack, fps = 24) # play framestack back at a target of 24 fps
+```
+
+Control keys are available in both modes:
+
+- `p` or `space-bar`: pause
+- `left` or `up-arrow`: step backward
+- `right` or `down-arrow`: step forward
+- `ctrl-c` or `q`: exit
+
 ## Troubleshooting
 
 If you see out of place horizontal lines in your Image it means

--- a/src/ImageInTerminal.jl
+++ b/src/ImageInTerminal.jl
@@ -5,7 +5,8 @@ using ImageCore
 using ImageTransformations
 
 export
-
+    play,
+    explore,
     colorant2ansi,
     imshow,
     imshow256,
@@ -14,6 +15,7 @@ export
 include("colorant2ansi.jl")
 include("encodeimg.jl")
 include("imshow.jl")
+include("multipage.jl")
 
 # -------------------------------------------------------------------
 # overload default show in the REPL for colorant (arrays)
@@ -62,7 +64,7 @@ enable_encoding() = (should_render_image[1] = true)
 function Base.show(
         io::IO, mime::MIME"text/plain",
         img::AbstractArray{<:Colorant})
-    if should_render_image[1]    
+    if should_render_image[1]
         println(io, summary(img), ":")
         ImageInTerminal.imshow(io, img, colormode[1])
     else
@@ -87,7 +89,7 @@ function __init__()
     # use 24bit if the terminal supports it
     lowercase(get(ENV, "COLORTERM", "")) in ("24bit", "truecolor") && use_24bit()
     enable_encoding()
-    
+
     if VERSION < v"1.6.0-DEV.888" && Sys.iswindows()
         # https://discourse.julialang.org/t/image-in-repl-does-not-correct/46359
         @warn "ImageInTerminal is not supported for Windows platform: Julia at least v1.6.0 is required."

--- a/src/multipage.jl
+++ b/src/multipage.jl
@@ -1,11 +1,8 @@
-
 ansi_moveup(n::Int) = string("\e[", n, "A")
 ansi_movecol1 = "\e[1G"
 ansi_cleartoend = "\e[0J"
 ansi_enablecursor = "\e[?25h"
 ansi_disablecursor = "\e[?25l"
-
-setraw!(io, raw) = ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), io.handle, raw)
 
 """
     play(io::IO, arr::T, dim::Int; kwargs...)
@@ -14,9 +11,9 @@ setraw!(io, raw) = ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), io.handle,
 Play a video of a framestack of image arrays, or 3D array along dimension `dim`.
 
 Control keys:
-- `p` or `space-bar`: pause
-- `left` or `up-arrow`: step backward
-- `right` or `down-arrow`: step forward
+- `p` or `space-bar`: pause/resume
+- `f`, `←`(left arrow), or `↑`(up arrow): step backward
+- `b`, `→`(right arrow), or `↓`(down arrow): step forward
 - `ctrl-c` or `q`: exit
 
 kwargs:
@@ -28,77 +25,73 @@ function play(io::IO, arr::T, dim::Int; fps::Real=30, maxsize::Tuple = displaysi
     @assert ndims(arr) <= 3 "Source array dimensions cannot exceed 3"
     firstframe = T <: Vector ? first(selectdim(arr, dim, 1)) : selectdim(arr, dim, 1)
     @assert eltype(firstframe) <: Colorant "Element type $(eltype(firstframe)) not supported"
-    # sizing
-    img_w, img_h = size(firstframe)
-    io_h, io_w = maxsize
-    blocks = 3img_w <= io_w ? BigBlocks() : SmallBlocks()
 
     # fixed
     nframes = size(arr, dim)
-    c = ImageInTerminal.colormode[]
 
     # vars
-    frame = 1
-    finished = false
-    first_print = true
+    frame_idx = 1
     actual_fps = 0
+    should_exit = false
 
-    println(summary(firstframe))
     keytask = @async begin
-        try
-            setraw!(stdin, true)
-            while !finished
-                keyin = read(stdin, Char)
-                if UInt8(keyin) == 27
-                    keyin = read(stdin, Char)
-                    if UInt8(keyin) == 91
-                        keyin = read(stdin, Char)
-                        UInt8(keyin) in [68,65] && (frame = frame <= 1 ? 1 : frame - 1) # left & up arrows
-                        UInt8(keyin) in [67,66] && (frame = frame >= nframes ? nframes : frame + 1) # right & down arrows
-                    end
-                end
-                keyin in ['p',' '] && (paused = !paused)
-                keyin in ['\x03','q'] && (finished = true)
+        while !should_exit
+            control_value = read_key()
+
+            if control_value == :CONTROL_BACKWARD
+                frame_idx = max(frame_idx-1, 1)
+            elseif control_value == :CONTROL_FORWARD
+                frame_idx = min(frame_idx+1, nframes)
+            elseif control_value == :CONTROL_PAUSE
+                paused = !paused
+            elseif control_value == :CONTROL_EXIT
+                should_exit = true
+            elseif control_value == :CONTROL_VOID
+                nothing
+            else
+                error("Control value $control_value not recognized.")
             end
-        catch
-        finally
-            setraw!(stdin, false)
         end
     end
+
+    print(ansi_disablecursor)
+    println(summary(selectdim(arr, dim, 1)))
+    render_frame(arr, dim, frame_idx, nframes, actual_fps, maxsize; first_frame=true)
+
     try
-        print(ansi_disablecursor)
-        setraw!(stdin, true)
-        while !finished
+        while !should_exit && 1<= frame_idx <= nframes
             tim = Timer(1/fps)
-            t = @elapsed begin
-                img = T <: Vector ? collect(first(selectdim(arr, dim, frame))) : selectdim(arr, dim, frame)
-                lines, rows, cols = encodeimg(blocks, c, img, io_h, io_w)
-                str = sprint() do ios
-                    println.((ios,), lines)
-                    if paused
-                        println(ios, "Preview: $(cols)x$(rows) Frame: $frame/$nframes", " "^15)
-                    else
-                        println(ios, "Preview: $(cols)x$(rows) Frame: $frame/$nframes FPS: $(round(actual_fps, digits=1))", " "^5)
-                    end
-                    println(ios, "exit: ctrl-c. play/pause: space-bar. seek: arrow keys")
-                end
-                first_print ? print(str) : print(ansi_moveup(rows+2), ansi_movecol1, str)
-                first_print = false
-                (!paused && frame == nframes) && break
-                !paused && (frame += 1)
-                wait(tim)
-            end
-            actual_fps = 1 / t
+            t = @elapsed render_frame(arr, dim, frame_idx, nframes, actual_fps, maxsize)
+            paused || (frame_idx += 1)
+            wait(tim)
+            actual_fps = paused ? 0 : 1 / t
         end
     catch e
-        isa(e,InterruptException) || rethrow()
+        e isa InterruptException || rethrow(e)
     finally
         print(ansi_enablecursor)
-        finished = true
+        # stop running read_key task so that REPL/stdin is not blocked
         @async Base.throwto(keytask, InterruptException())
         wait(keytask)
     end
-    return
+    return nothing
+end
+
+function render_frame(arr, dim, frame_idx, nframes, actual_fps, maxsize; first_frame=false)
+    frame = selectdim(arr, dim, frame_idx)
+
+    # sizing
+    frame_w, frame_h = size(frame)
+    io_h, io_w = maxsize
+    blocks = 3frame_w <= io_w ? BigBlocks() : SmallBlocks()
+
+    lines, rows, cols = encodeimg(blocks, ImageInTerminal.colormode[], frame, io_h, io_w)
+    if !first_frame
+        print(ansi_moveup(rows+2), ansi_movecol1)
+    end
+    println.(lines)
+    println("Preview: $(cols)x$(rows) Frame: $frame_idx/$nframes FPS: $(round(actual_fps, digits=1))", " "^5)
+    println("exit: ctrl-c. play/pause: space-bar. seek: arrow keys")
 end
 play(arr::T, dim::Int; kwargs...) where {T<:AbstractArray} = play(stdout, arr, dim; kwargs...)
 play(io::IO, framestack::Vector{T}; kwargs...) where {T<:AbstractArray} = play(io, framestack, 1; kwargs...)
@@ -115,3 +108,64 @@ explore(io::IO, arr::T, dim::Int; kwargs...) where {T<:AbstractArray} = play(io,
 explore(arr::T, dim::Int; kwargs...) where {T<:AbstractArray} = play(stdout, arr, dim; paused=true, kwargs...)
 explore(io::IO, framestack::Vector{T}; kwargs...) where {T<:AbstractArray} = explore(io, framestack, 1; kwargs...)
 explore(framestack::Vector{T}; kwargs...) where {T<:AbstractArray} = explore(stdout, framestack, 1; kwargs...)
+
+
+# minimal keyboard event support
+"""
+    read_key() -> control_value
+
+read control key from keyboard input.
+
+# Reference table
+
+| value               | control_value     | effect                 |
+| ------------------- | ----------------- | -------------------    |
+| UP, LEFT, f, F      | :CONTROL_BACKWARD | show previous frame    |
+| DOWN, RIGHT, b, B   | :CONTROL_FORWARD  | show next frame        |
+| SPACE, p, P         | :CONTROL_PAUSE    | pause/resume play      |
+| CTRL-c, q, Q        | :CONTROL_EXIT     | exit current play      |
+| others...           | :CONTROL_VOID     | no effect              |
+"""
+function read_key()
+    setraw!(io, raw) = ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), io.handle, raw)
+    control_value = :CONTROL_VOID
+    try
+        setraw!(stdin, true)
+        keyin = read(stdin, Char)
+        if keyin == '\e'
+            # some special keys are more than one bit, e.g., left key is `\e[D`
+            # reference: https://en.wikipedia.org/wiki/ANSI_escape_code
+            keyin = read(stdin, Char)
+            if keyin == '['
+                keyin = read(stdin, Char)
+                if keyin in ['A', 'D'] # up, left
+                    control_value = :CONTROL_BACKWARD
+                elseif keyin in ['B', 'C'] # down, right
+                    control_value = :CONTROL_FORWARD
+                end
+            end
+        elseif 'A' <= keyin <= 'Z' || 'a' <= keyin <= 'z'
+            keyin = lowercase(keyin)
+            if keyin == 'p'
+                control_value = :CONTROL_PAUSE
+            elseif keyin == 'q'
+                control_value = :CONTROL_EXIT
+            elseif keyin == 'f'
+                control_value = :CONTROL_FORWARD
+            elseif keyin == 'b'
+                control_value = :CONTROL_BACKWARD
+            end
+        elseif keyin == ' '
+            control_value = :CONTROL_PAUSE
+        end
+    catch e
+        if e isa InterruptException # Ctrl-C
+            control_value = :CONTROL_EXIT
+        else
+            rethrow(e)
+        end
+    finally
+        setraw!(stdin, false)
+    end
+    return control_value
+end

--- a/src/multipage.jl
+++ b/src/multipage.jl
@@ -1,0 +1,117 @@
+
+ansi_moveup(n::Int) = string("\e[", n, "A")
+ansi_movecol1 = "\e[1G"
+ansi_cleartoend = "\e[0J"
+ansi_enablecursor = "\e[?25h"
+ansi_disablecursor = "\e[?25l"
+
+setraw!(io, raw) = ccall(:jl_tty_set_mode, Int32, (Ptr{Cvoid},Int32), io.handle, raw)
+
+"""
+    play(io::IO, arr::T, dim::Int; kwargs...)
+    play(io::IO, framestack::Vector{T}; kwargs...) where {T<:AbstractArray}
+
+Play a video of a framestack of image arrays, or 3D array along dimension `dim`.
+
+Control keys:
+- `p` or `space-bar`: pause
+- `left` or `up-arrow`: step backward
+- `right` or `down-arrow`: step forward
+- `ctrl-c` or `q`: exit
+
+kwargs:
+- `fps::Real=30`
+- `maxsize::Tuple = displaysize(io)`
+"""
+function play(io::IO, arr::T, dim::Int; fps::Real=30, maxsize::Tuple = displaysize(io), paused = false) where {T<:AbstractArray}
+    @assert dim <= ndims(arr) "Requested dimension $dim, but source array only has $(ndims(arr)) dimensions"
+    @assert ndims(arr) <= 3 "Source array dimensions cannot exceed 3"
+    firstframe = T <: Vector ? first(selectdim(arr, dim, 1)) : selectdim(arr, dim, 1)
+    @assert eltype(firstframe) <: Colorant "Element type $(eltype(firstframe)) not supported"
+    # sizing
+    img_w, img_h = size(firstframe)
+    io_h, io_w = maxsize
+    blocks = 3img_w <= io_w ? BigBlocks() : SmallBlocks()
+
+    # fixed
+    nframes = size(arr, dim)
+    c = ImageInTerminal.colormode[]
+
+    # vars
+    frame = 1
+    finished = false
+    first_print = true
+    actual_fps = 0
+
+    println(summary(firstframe))
+    keytask = @async begin
+        try
+            setraw!(stdin, true)
+            while !finished
+                keyin = read(stdin, Char)
+                if UInt8(keyin) == 27
+                    keyin = read(stdin, Char)
+                    if UInt8(keyin) == 91
+                        keyin = read(stdin, Char)
+                        UInt8(keyin) in [68,65] && (frame = frame <= 1 ? 1 : frame - 1) # left & up arrows
+                        UInt8(keyin) in [67,66] && (frame = frame >= nframes ? nframes : frame + 1) # right & down arrows
+                    end
+                end
+                keyin in ['p',' '] && (paused = !paused)
+                keyin in ['\x03','q'] && (finished = true)
+            end
+        catch
+        finally
+            setraw!(stdin, false)
+        end
+    end
+    try
+        print(ansi_disablecursor)
+        setraw!(stdin, true)
+        while !finished
+            tim = Timer(1/fps)
+            t = @elapsed begin
+                img = T <: Vector ? collect(first(selectdim(arr, dim, frame))) : selectdim(arr, dim, frame)
+                lines, rows, cols = encodeimg(blocks, c, img, io_h, io_w)
+                str = sprint() do ios
+                    println.((ios,), lines)
+                    if paused
+                        println(ios, "Preview: $(cols)x$(rows) Frame: $frame/$nframes", " "^15)
+                    else
+                        println(ios, "Preview: $(cols)x$(rows) Frame: $frame/$nframes FPS: $(round(actual_fps, digits=1))", " "^5)
+                    end
+                    println(ios, "exit: ctrl-c. play/pause: space-bar. seek: arrow keys")
+                end
+                first_print ? print(str) : print(ansi_moveup(rows+2), ansi_movecol1, str)
+                first_print = false
+                (!paused && frame == nframes) && break
+                !paused && (frame += 1)
+                wait(tim)
+            end
+            actual_fps = 1 / t
+        end
+    catch e
+        isa(e,InterruptException) || rethrow()
+    finally
+        print(ansi_enablecursor)
+        finished = true
+        @async Base.throwto(keytask, InterruptException())
+        wait(keytask)
+    end
+    return
+end
+play(arr::T, dim::Int; kwargs...) where {T<:AbstractArray} = play(stdout, arr, dim; kwargs...)
+play(io::IO, framestack::Vector{T}; kwargs...) where {T<:AbstractArray} = play(io, framestack, 1; kwargs...)
+
+"""
+    explore(io::IO, arr::T, dim::Int; kwargs...) where {T<:AbstractArray}
+    explore(arr::T, dim::Int; kwargs...) where {T<:AbstractArray}
+    explore(io::IO, framestack::Vector{T}; kwargs...) where {T<:AbstractArray}
+    explore(framestack::Vector{T}; kwargs...) where {T<:AbstractArray}
+
+Like `play`, but starts paused
+"""
+explore(io::IO, arr::T, dim::Int; kwargs...) where {T<:AbstractArray} = play(io, arr, dim; paused=true, kwargs...)
+explore(arr::T, dim::Int; kwargs...) where {T<:AbstractArray} = play(stdout, arr, dim; paused=true, kwargs...)
+explore(io::IO, framestack::Vector{T}; kwargs...) where {T<:AbstractArray} = explore(io, framestack, 1; kwargs...)
+explore(framestack::Vector{T}; kwargs...) where {T<:AbstractArray} = explore(stdout, framestack, 1; kwargs...)


### PR DESCRIPTION
I thought these methods would make more sense in here than in https://github.com/IanButterworth/VideoInTerminal.jl given they require no further deps, and feel like an extension of current ImageInTerminal offerings.

```julia
using ImageInTerminal, TestImages
img3D = testimage("mri-stack")
explore(img3D, 3) # explore along dimension 3
play(img3D, 3) # play along dimension 3 (like explore but start playing, and exit when done)
```
<img width="576" alt="explore_mri" src="https://user-images.githubusercontent.com/1694067/109374814-1351a280-7886-11eb-956e-c08403ae9afb.png">

```julia
using ImageInTerminal, ImageCore
framestack = map(_->rand(Gray{N0f8}, 100, 100), 1:200)
play(framestack, fps = 24) # play framestack back at a target of 24 fps
explore(framestack, fps = 24) # like play, but start paused
```

The methods that depend on VideoIO could stay in [VideoInTerminal](https://github.com/IanButterworth/VideoInTerminal.jl) (like the webcam viewer.. which I recommend trying out!)

```julia
pkg> add https://github.com/IanButterworth/VideoInTerminal.jl 
julia> using VideoInTerminal
julia> showcam()
```

It's so awesome how well this works ImageInTerminal. The frame rates are really impressive. Nice work!

