### PR TITLE
remove inferred check for show

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         julia-version: ['1.0', '1', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ function ensurecolor(f, args...)
     old_color = Base.have_color
     try
         Core.eval(Base, :(have_color = true))
-        return @inferred f(args...)
+        return f(args...)
     finally
         Core.eval(Base, :(have_color = $old_color))
     end


### PR DESCRIPTION
We don't need the return value of `show`, whcih is `nothing`, hence the
`@inferred` check is unnecessary. Since it breaks the test for Julia 1.6,
I removed it here.

Also, disable fail-fast in GHA so that other jobs can still run even if nightly job fails.