### PR TITLE
CI(UnitTest): replace Julia 1.0 with 1.6

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -1,5 +1,4 @@
 name: Unit test
-
 on:
   create:
     tags:
@@ -7,32 +6,35 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
+defaults:
+  run:
+    shell: bash
 
 jobs:
   test:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        version:
+          - '1.6'   # oldest supported in Project.toml
+          - '1'     # latest stable
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        include:  # spare windows/macos CI credits
+          - os: windows-latest
+            version: '1'
+          - os: macOS-latest
+            version: '1'
 
     steps:
-      - uses: actions/checkout@v1.0.0
-      - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}
-      - name: "Compat fix for Julia < v1.3.0"
-        if: ${{ matrix.julia-version == '1.0' }}
-        run: |
-          using Pkg
-          Pkg.add([
-            PackageSpec(name="AbstractFFTs", version="0.5"),
-          ])
-        shell: julia --project=. --startup=no --color=yes {0}
+          version: ${{ matrix.version }}
       - name: Cache artifacts
         uses: actions/cache@v1
         env:
@@ -44,9 +46,5 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - name: "Unit Test"
-        uses: julia-actions/julia-runtest@master
-
-      # Unless tokenless upload is enabled, we can only submit coverage via
-      # environment variable. But PRs from other fork can't do that.
-      # See issue: https://github.com/julia-actions/julia-uploadcodecov/issues/1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
This is the first patch separated from #58 

Except for the simplification and template upgrades, there are two
worth-noting changes in this commit:

- replaces Julia 1.0 with Julia 1.6 (the new LTS version).
- only test windows/macOS on Julia 1
- remove scheduled jobs; this is because otherwise GitHub would automatically disable the action after 30/60 days inactivity.