### PR TITLE
correct 8bit color encoding

### DIFF
--- a/AsciiPixel/src/colorant2ansi.jl
+++ b/AsciiPixel/src/colorant2ansi.jl
@@ -2,6 +2,13 @@ abstract type TermColorDepth end
 struct TermColor8bit <: TermColorDepth end
 struct TermColor24bit <: TermColorDepth end
 
+ansi_color(c) = Int(Crayons.to_256_colors(Crayons._parse_color(c)).r)
+rgb_24bit(c) = map(x -> round(Int, 255x), clamp01nan.((red(c), green(c), blue(c))))
+function gray_24bit(c)
+    r = round(Int, 255clamp01nan(real(c)))
+    r, r, r
+end
+
 """
     colorant2ansi(color::Colorant) -> Int
 
@@ -27,36 +34,276 @@ julia> colorant2ansi(Gray(.5))
 colorant2ansi(color) = _colorant2ansi(color, TermColor8bit())
 
 # Fallback for non-rgb and transparent colors (convert to rgb)
-_colorant2ansi(gr::Color, colordepth::TermColorDepth) =
-    _colorant2ansi(convert(RGB, gr), colordepth)
-
-_colorant2ansi(gr::TransparentColor, colordepth::TermColorDepth) =
-    _colorant2ansi(color(gr), colordepth)
+_colorant2ansi(gr::Color, colordepth::TermColorDepth) = _colorant2ansi(convert(RGB, gr), colordepth)
+_colorant2ansi(gr::TransparentColor, colordepth::TermColorDepth) = _colorant2ansi(color(gr), colordepth)
 
 # 8bit (256) colors
-function _colorant2ansi(col::AbstractRGB, ::TermColor8bit)
-    r, g, b = clamp01nan(red(col)), clamp01nan(green(col)), clamp01nan(blue(col))
-    r24, g24, b24 = map(c -> round(Int, 23c), (r, g, b))
-    if r24 == g24 == b24
-        # Use grayscales because of higher resolution
-        # This way even grayscale RGB images look good.
-        232 + r24
-    else
-        r6, g6, b6 = map(c -> round(Int, 5c), (r, g, b))
-        16 + 36r6 + 6g6 + b6
-    end
-end
-
-_colorant2ansi(gr::Color{<:Any,1}, ::TermColor8bit) =
-    round(Int, 232 + 23clamp01nan(real(gr)))
+_colorant2ansi(col::AbstractRGB, ::TermColor8bit) = ansi_color(rgb_24bit(col))
+_colorant2ansi(gr::Union{AbstractGray,Color{<:Any,1}}, ::TermColor8bit) = ansi_color(gray_24bit(gr))
 
 # 24 bit colors
-function _colorant2ansi(col::AbstractRGB, ::TermColor24bit)
-    r, g, b = clamp01nan(red(col)), clamp01nan(green(col)), clamp01nan(blue(col))
-    map(c -> round(Int, 255c), (r, g, b))
-end
+_colorant2ansi(col::AbstractRGB, ::TermColor24bit) = rgb_24bit(col)
+_colorant2ansi(gr::Union{AbstractGray,Color{<:Any,1}}, ::TermColor24bit) = gray_24bit(gr)
 
-function _colorant2ansi(gr::Color{<:Any,1}, ::TermColor24bit)
-    r = round(Int, 255clamp01nan(real(gr)))
-    r, r, r
-end
+(enc::TermColor8bit)(c::Union{AbstractRGB,AbstractGray}) = _colorant2ansi(c, enc)
+(enc::TermColor8bit)(idx::Integer) = RGB(reinterpret(ARGB32, TERMCOLOR256_LOOKUP[1 + idx]))
+
+# https://www.ditig.com/256-colors-cheat-sheet
+const TERMCOLOR256_LOOKUP = [
+    0x000000,  # vvv primary 3-bit (8 colors)
+    0x800000,
+    0x008000,
+    0x808000,
+    0x000080,
+    0x800080,
+    0x008080,
+    0xc0c0c0,
+    0x808080,  # vvv equivalent "bright" versions of original 8 colors
+    0xff0000,
+    0x00ff00,
+    0xffff00,
+    0x0000ff,
+    0xff00ff,
+    0x00ffff,
+    0xffffff,
+    0x000000,  # vvv strictly ascending
+    0x00005f,
+    0x000087,
+    0x0000af,
+    0x0000d7,
+    0x0000ff,
+    0x005f00,
+    0x005f5f,
+    0x005f87,
+    0x005faf,
+    0x005fd7,
+    0x005fff,
+    0x008700,
+    0x00875f,
+    0x008787,
+    0x0087af,
+    0x0087d7,
+    0x0087ff,
+    0x00af00,
+    0x00af5f,
+    0x00af87,
+    0x00afaf,
+    0x00afd7,
+    0x00afff,
+    0x00d700,
+    0x00d75f,
+    0x00d787,
+    0x00d7af,
+    0x00d7d7,
+    0x00d7ff,
+    0x00ff00,
+    0x00ff5f,
+    0x00ff87,
+    0x00ffaf,
+    0x00ffd7,
+    0x00ffff,
+    0x5f0000,
+    0x5f005f,
+    0x5f0087,
+    0x5f00af,
+    0x5f00d7,
+    0x5f00ff,
+    0x5f5f00,
+    0x5f5f5f,
+    0x5f5f87,
+    0x5f5faf,
+    0x5f5fd7,
+    0x5f5fff,
+    0x5f8700,
+    0x5f875f,
+    0x5f8787,
+    0x5f87af,
+    0x5f87d7,
+    0x5f87ff,
+    0x5faf00,
+    0x5faf5f,
+    0x5faf87,
+    0x5fafaf,
+    0x5fafd7,
+    0x5fafff,
+    0x5fd700,
+    0x5fd75f,
+    0x5fd787,
+    0x5fd7af,
+    0x5fd7d7,
+    0x5fd7ff,
+    0x5fff00,
+    0x5fff5f,
+    0x5fff87,
+    0x5fffaf,
+    0x5fffd7,
+    0x5fffff,
+    0x870000,
+    0x87005f,
+    0x870087,
+    0x8700af,
+    0x8700d7,
+    0x8700ff,
+    0x875f00,
+    0x875f5f,
+    0x875f87,
+    0x875faf,
+    0x875fd7,
+    0x875fff,
+    0x878700,
+    0x87875f,
+    0x878787,
+    0x8787af,
+    0x8787d7,
+    0x8787ff,
+    0x87af00,
+    0x87af5f,
+    0x87af87,
+    0x87afaf,
+    0x87afd7,
+    0x87afff,
+    0x87d700,
+    0x87d75f,
+    0x87d787,
+    0x87d7af,
+    0x87d7d7,
+    0x87d7ff,
+    0x87ff00,
+    0x87ff5f,
+    0x87ff87,
+    0x87ffaf,
+    0x87ffd7,
+    0x87ffff,
+    0xaf0000,
+    0xaf005f,
+    0xaf0087,
+    0xaf00af,
+    0xaf00d7,
+    0xaf00ff,
+    0xaf5f00,
+    0xaf5f5f,
+    0xaf5f87,
+    0xaf5faf,
+    0xaf5fd7,
+    0xaf5fff,
+    0xaf8700,
+    0xaf875f,
+    0xaf8787,
+    0xaf87af,
+    0xaf87d7,
+    0xaf87ff,
+    0xafaf00,
+    0xafaf5f,
+    0xafaf87,
+    0xafafaf,
+    0xafafd7,
+    0xafafff,
+    0xafd700,
+    0xafd75f,
+    0xafd787,
+    0xafd7af,
+    0xafd7d7,
+    0xafd7ff,
+    0xafff00,
+    0xafff5f,
+    0xafff87,
+    0xafffaf,
+    0xafffd7,
+    0xafffff,
+    0xd70000,
+    0xd7005f,
+    0xd70087,
+    0xd700af,
+    0xd700d7,
+    0xd700ff,
+    0xd75f00,
+    0xd75f5f,
+    0xd75f87,
+    0xd75faf,
+    0xd75fd7,
+    0xd75fff,
+    0xd78700,
+    0xd7875f,
+    0xd78787,
+    0xd787af,
+    0xd787d7,
+    0xd787ff,
+    0xd7af00,
+    0xd7af5f,
+    0xd7af87,
+    0xd7afaf,
+    0xd7afd7,
+    0xd7afff,
+    0xd7d700,
+    0xd7d75f,
+    0xd7d787,
+    0xd7d7af,
+    0xd7d7d7,
+    0xd7d7ff,
+    0xd7ff00,
+    0xd7ff5f,
+    0xd7ff87,
+    0xd7ffaf,
+    0xd7ffd7,
+    0xd7ffff,
+    0xff0000,
+    0xff005f,
+    0xff0087,
+    0xff00af,
+    0xff00d7,
+    0xff00ff,
+    0xff5f00,
+    0xff5f5f,
+    0xff5f87,
+    0xff5faf,
+    0xff5fd7,
+    0xff5fff,
+    0xff8700,
+    0xff875f,
+    0xff8787,
+    0xff87af,
+    0xff87d7,
+    0xff87ff,
+    0xffaf00,
+    0xffaf5f,
+    0xffaf87,
+    0xffafaf,
+    0xffafd7,
+    0xffafff,
+    0xffd700,
+    0xffd75f,
+    0xffd787,
+    0xffd7af,
+    0xffd7d7,
+    0xffd7ff,
+    0xffff00,
+    0xffff5f,
+    0xffff87,
+    0xffffaf,
+    0xffffd7,
+    0xffffff,
+    0x080808,  # vvv gray-scale range
+    0x121212,
+    0x1c1c1c,
+    0x262626,
+    0x303030,
+    0x3a3a3a,
+    0x444444,
+    0x4e4e4e,
+    0x585858,
+    0x626262,
+    0x6c6c6c,
+    0x767676,
+    0x808080,
+    0x8a8a8a,
+    0x949494,
+    0x9e9e9e,
+    0xa8a8a8,
+    0xb2b2b2,
+    0xbcbcbc,
+    0xc6c6c6,
+    0xd0d0d0,
+    0xdadada,
+    0xe4e4e4,
+    0xeeeeee,
+]

--- a/AsciiPixel/test/tst_colorant2ansi.jl
+++ b/AsciiPixel/test/tst_colorant2ansi.jl
@@ -6,28 +6,64 @@
     # 8bit (256) ansi color codes is correct
     @testset "8bit colors" begin
         # reference functions to compare against
-        function _ref_col2ansi(r, g, b)
-            r6, g6, b6 = map(c -> round(Int, 5c), (r, g, b))
-            16 + 36r6 + 6g6 + b6
-        end
-        function _ref_col2ansi(gr)
-            round(Int, 232 + 23gr)
-        end
-        @testset "RGB" begin
-            for col in rand(RGB, 10)
-                r, g, b = red(col), green(col), blue(col)
-                ri, gi, bi = map(c -> round(Int, 23c), (r, g, b))
-                if ri == gi == bi
-                    @test _colorant2ansi(col, TermColor8bit()) === _ref_col2ansi(r)
-                else
-                    @test _colorant2ansi(col, TermColor8bit()) === _ref_col2ansi(r, g, b)
+        # function _ref_col2ansi(r, g, b)
+        #     r24, g24, b24 = map(c->round(Int, 23c), (r, g, b))
+        #     if r24 == g24 == b24
+        #         # RGB scale color code
+        #         r24 == 0 && return 16   # 0x000000
+        #         r24 == 9 && return 59   # 0x5f5f5f
+        #         r24 == 12 && return 102 # 0x878787
+        #         r24 == 16 && return 145 # 0xafafaf
+        #         r24 == 19 && return 188 # 0xd7d7d7
+        #         r24 == 23 && return 231 # 0xffffff
+        #         # gray scale color code
+        #         232 + r24
+        #     else
+        #         r6, g6, b6 = map(c -> round(Int, 5c), (r, g, b))
+        #         16 + 36r6 + 6g6 + b6
+        #     end
+        # end
+        # function _ref_col2ansi(gr)
+        #     val = round(Int, 23clamp01nan(gr))
+        #     val == 0 && return 0   # 0x000000
+        #     val > 24 && return 231  # 0xffffff
+        #     232 + val
+        # end
+        # @testset "RGB" begin
+        #     for col in rand(RGB, 10)
+        #         r, g, b = red(col), green(col), blue(col)
+        #         ri, gi, bi = map(c -> round(Int, 23c), (r, g, b))
+        #         if ri == gi == bi
+        #             @test _colorant2ansi(col, TermColor8bit()) === _ref_col2ansi(r)
+        #         else
+        #             @test _colorant2ansi(col, TermColor8bit()) === _ref_col2ansi(r, g, b)
+        #         end
+        #     end
+        # end
+        # @testset "Gray" begin
+        #     for col in rand(Gray, 10)
+        #         r = real(col)
+        #         @test _colorant2ansi(col, TermColor8bit()) === _ref_col2ansi(r)
+        #     end
+        # end
+
+        @testset "decoder" begin
+            enc = TermColor8bit()
+
+            @testset "RGB scale" begin
+                for idx in 16:231
+                    ccode = AsciiPixel.TERMCOLOR256_LOOKUP[1 + idx]
+                    c = RGB(reinterpret(ARGB32, ccode))
+                    @test enc(c) == (idx == 16 ? 0 : idx)
                 end
             end
-        end
-        @testset "Gray" begin
-            for col in rand(Gray, 10)
-                r = real(col)
-                @test _colorant2ansi(col, TermColor8bit()) === _ref_col2ansi(r)
+
+            @testset "Gray scale" begin
+                for idx in 232:255
+                    ccode = AsciiPixel.TERMCOLOR256_LOOKUP[1 + idx]
+                    c = Gray(red(RGB(reinterpret(ARGB32, ccode))))
+                    @test enc(c) == idx
+                end
             end
         end
     end

--- a/src/ImageInTerminal.jl
+++ b/src/ImageInTerminal.jl
@@ -15,6 +15,7 @@ import Sixel
 const encoder_backend = Ref(:ImageInTerminal)
 const should_render_image = Ref(true)
 const small_imgs_sixel = Ref(false)
+const print_summary = Ref(true)
 
 """
     disable_encoding()
@@ -62,7 +63,7 @@ end
 # colorant arrays
 function Base.show(io::IO, mime::MIME"text/plain", img::AbstractArray{<:Colorant})
     if should_render_image[]
-        println(io, summary(img), ":")
+        print_summary[] && println(io, summary(img), ":")
         imshow(io, img)
     else
         invoke(Base.show, Tuple{typeof(io),typeof(mime),AbstractArray}, io, mime, img)

--- a/src/display.jl
+++ b/src/display.jl
@@ -18,5 +18,5 @@ function Base.display(
 )
     println(d.summary_stream, summary(img), ":")
     ImageInTerminal.imshow(d.content_stream, img, colormode[1])
-    return nothing
+    nothing
 end


### PR DESCRIPTION
Superseding https://github.com/JuliaImages/ImageInTerminal.jl/pull/62.

```julia
using ImageInTerminal, OffsetArrays, ImageCore

colorwheel(sz::Dims{2}, v=1) = begin
  # H, S
  canvas = OffsetArrays.centered(fill(RGB(0, 0, 0), sz))

  for I ∈ CartesianIndices(canvas)
    x, y = I.I ./ (size(canvas) .÷ 2)
    r = sqrt(x^2 + y^2)
    if r < 1
      h = atand(x, y) + 90
      canvas[I] = RGB(HSV(h, r, v))
    end
  end
  canvas
end

main() = begin
  rgbwheel = colorwheel((512, 512))
  graybar = Gray{N0f8}.(transpose(repeat(range(0, stop=1, length=256), 1, 80)))

  enc = ImageInTerminal.AsciiPixel.TermColor8bit()
  display(enc.(enc.(rgbwheel)))
  display(enc.(enc.(graybar)))
  return
end

main()
```