### PR TITLE
fix detection of small RGB images

### DIFF
--- a/src/ImageInTerminal.jl
+++ b/src/ImageInTerminal.jl
@@ -55,8 +55,8 @@ function choose_sixel(img::AbstractArray)
         # Small images really do not need sixel encoding.
         # `60` is a randomly chosen value (10 sixel); it's not the best because
         # 60x60 image will be very small in terminal after sixel encoding.
-        any(size(img) .≤ 12) && return false
-        all(size(img) .≤ 60) && return false
+        any(size(img)[1:2] .≤ 12) && return false
+        all(size(img)[1:2] .≤ 60) && return false
         return true
     end
 end


### PR DESCRIPTION
Small RGB images are not shown with the Sixel backend, because RGB triples are misinterpreted as dimension of length 3.
See, for example
```julia
using ColorTypes, ImageInTerminal, Sixel
img = mapslices(rgb -> ColorTypes.RGB{Float64}(rgb[1], rgb[2], rgb[3]), rand(100, 100, 3), dims = 3)
````
The code in question is on lines 58, 59 in ImageInTerminal.jl
```julia
        any(size(img) .≤ 12) && return false
        all(size(img) .≤ 60) && return false
```
This PR changes this to
```julia
        any(size(img)[1:2] .≤ 12) && return false
        all(size(img)[1:2] .≤ 60) && return false
```
