### PR TITLE
Add support to display PNG for arbitrary types

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -4,7 +4,15 @@ struct TerminalGraphicDisplay{TC<:IO,TS<:IO} <: AbstractDisplay
 end
 TerminalGraphicDisplay(io::IO) = TerminalGraphicDisplay(io, io)
 
-Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png") = true
+Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png", x::Any) = showable("image/png", x)
+Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png", ::Vector{UInt8}) = true
+Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png", ::AbstractArray{<:Colorant}) = true
+
+function Base.display(d::TerminalGraphicDisplay, ::MIME"image/png", x::Any)
+    io = IOBuffer()
+    show(io, "image/png", x)
+    display(d, MIME("image/png"), FileIO.load(io))
+end
 
 function Base.display(d::TerminalGraphicDisplay, ::MIME"image/png", bytes::Vector{UInt8})
     # In this case, assume it to be png byte sequences, use FileIO to find a decoder for it.

--- a/src/display.jl
+++ b/src/display.jl
@@ -4,9 +4,11 @@ struct TerminalGraphicDisplay{TC<:IO,TS<:IO} <: AbstractDisplay
 end
 TerminalGraphicDisplay(io::IO) = TerminalGraphicDisplay(io, io)
 
-Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png", x::Any) = showable("image/png", x)
+Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png", x::Any) =
+    showable("image/png", x)
 Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png", ::Vector{UInt8}) = true
-Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png", ::AbstractArray{<:Colorant}) = true
+Base.displayable(::TerminalGraphicDisplay, ::MIME"image/png", ::AbstractArray{<:Colorant}) =
+    true
 
 function Base.display(d::TerminalGraphicDisplay, ::MIME"image/png", x::Any)
     io = IOBuffer()

--- a/test/tst_display.jl
+++ b/test/tst_display.jl
@@ -17,7 +17,8 @@
     @test length(read(io, String)) > 5_000
 
     struct Foo end
-    Base.show(io::IO, ::MIME"image/png", ::Foo) = FileIO.save(Stream{format"PNG"}(io), FileIO.load(fn))
+    Base.show(io::IO, ::MIME"image/png", ::Foo) =
+        FileIO.save(Stream{format"PNG"}(io), FileIO.load(fn))
     dsp = ImageInTerminal.TerminalGraphicDisplay(io)
     display(dsp, MIME("image/png"), Foo())
     @test length(read(io, String)) > 5_000

--- a/test/tst_display.jl
+++ b/test/tst_display.jl
@@ -15,4 +15,10 @@
     dsp = ImageInTerminal.TerminalGraphicDisplay(io)
     display(dsp, MIME("image/png"), bytes)
     @test length(read(io, String)) > 5_000
+
+    struct Foo end
+    Base.show(io::IO, ::MIME"image/png", ::Foo) = FileIO.save(Stream{format"PNG"}(io), FileIO.load(fn))
+    dsp = ImageInTerminal.TerminalGraphicDisplay(io)
+    display(dsp, MIME("image/png"), Foo())
+    @test length(read(io, String)) > 5_000
 end


### PR DESCRIPTION
This would allow to display images for arbitrary user types, as long as they provide an implementation for `Base.show` for the MIME type `image/png` as described at https://docs.julialang.org/en/v1/manual/types/#man-custom-pretty-printing.

Example:
```julia
julia> using PNGFiles, TesetImages, ImageInTerminal

julia> struct Foo end

julia> Base.show(io::IO, ::MIME"image/png", ::Foo) = PNGFiles.save(io, testimage("mandrill"))

julia> foo = Foo()

julia> display("image/png", foo)
```

![ImageInTerminal](https://github.com/JuliaImages/ImageInTerminal.jl/assets/6579999/8f9fa474-4b4f-43a9-b837-17341c89a443)